### PR TITLE
Readme: installation instruction should have ref = 'main'

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -100,7 +100,7 @@ You can install from [GitHub](https://github.com/coolbutuseless/emphatic) with:
 
 ``` r
 # install.package('remotes')
-remotes::install_github('coolbutuseless/emphatic')
+remotes::install_github('coolbutuseless/emphatic', ref = 'main')
 ```
 
 Warning

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can install from
 
 ``` r
 # install.package('remotes')
-remotes::install_github('coolbutuseless/emphatic')
+remotes::install_github('coolbutuseless/emphatic', ref = 'main')
 ```
 
 ## Warning


### PR DESCRIPTION
Hello me again! Since you have your main branch as 'main', until `remotes` also adjusts its default branch the `ref = 'main'` parameter will need to be passed to download using `install_github`.