### PR TITLE
README.md: `install.package` -> `install.packages`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can install from
 [GitHub](https://github.com/coolbutuseless/emphatic) with:
 
 ``` r
-# install.package('remotes')
+# install.packages('remotes')
 remotes::install_github('coolbutuseless/emphatic', ref = 'main')
 ```
 


### PR DESCRIPTION
I'm an R ~~idiot~~ novice and it took me embarrassingly too long to realize that the comment should say `install.packages` instead of `install.package`.